### PR TITLE
Fix minor header issues

### DIFF
--- a/include/MatrixOps.h
+++ b/include/MatrixOps.h
@@ -1,4 +1,4 @@
-#ifndef MARTIX_OPS_H
+#ifndef MATRIX_OPS_H
 #define MATRIX_OPS_H
 #include <string>
 

--- a/include/NeuralNet.h
+++ b/include/NeuralNet.h
@@ -51,7 +51,7 @@ public:
     ~NeuralNet();
 
     // Network setup and training
-    void NeuralNet::initialize(int inputSize, int* Nuerons, int hiddenLayers, int outputFeatures);   
+    void initialize(int inputSize, int* Nuerons, int hiddenLayers, int outputFeatures);
     void train(const float* trainingData,
                int numDays,
                int lookback,


### PR DESCRIPTION
## Summary
- correct typo in `MATRIX_OPS_H` guard
- remove class qualifier in `NeuralNet` initialization declaration

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef090874832ca9db7ec44de32f48